### PR TITLE
Add instructions for building the C Veraison client.

### DIFF
--- a/mbedtls-build.md
+++ b/mbedtls-build.md
@@ -40,13 +40,39 @@ sudo install -m 644  inc/ctoken/ctoken* /usr/local/include/ctoken
 sudo install -m 644 libctoken.a /usr/local/lib
 ```
 
+## Build the Veraison C Client
+
+The mbedTLS demo uses [Veraison](https://github.com/veraison) for verification of attestation evidence. The
+`ssl_server2` example program needs to make REST API calls to a suitable Veraison endpoint. In order to do this,
+it consumes the C client for the Veraison challenge-response API.
+
+The C client library is actually a wrapper of the Rust client library, so you must first
+[install the Rust toolchain](https://www.rust-lang.org/tools/install).
+
+Install the Veraison C API client as follows:
+
+```sh
+git clone https://github.com/veraison/rust-apiclient
+cd rust-apiclient
+cargo build
+```
+
+Again, a bit of DIY is needed in order to install the C wrapper pieces into a conventional location so that
+mbedTLS can find the include files and the link library:
+
+```sh
+sudo mkdir -p /usr/local/include/veraison
+sudo install -m 644 c-wrapper/veraison_client_wrapper.h /usr/local/include/veraison/
+sudo install -m 644 ./target/debug/libveraison_apiclient_ffi.a /usr/local/lib/
+```
+
 ## Build modified mbedTLS
 
 ```
 git clone https://github.com/hannestschofenig/mbedtls
 cd mbedtls
 git checkout tls-attestation
-make CFLAGS="-DCTOKEN_LABEL_CNF=8 -DCTOKEN_TEMP_LABEL_KAK_PUB=2500" LDFLAGS="-lqcbor -lctoken -lt_cose"
+make CFLAGS="-DCTOKEN_LABEL_CNF=8 -DCTOKEN_TEMP_LABEL_KAK_PUB=2500" LDFLAGS="-lqcbor -lctoken -lt_cose -lveraison_apiclient_ffi"
 ```
 
 ## Running the EAT example


### PR DESCRIPTION
Add Veraison C client (Rust wrapper) as prerequisite for building the modified mbedTLS.

Signed-off-by: Paul Howard <paul.howard@arm.com>