### PR TITLE
Establish Docker images for relying party and (mocked) verifier

### DIFF
--- a/demo/relying-party/relying-party.Dockerfile
+++ b/demo/relying-party/relying-party.Dockerfile
@@ -1,0 +1,87 @@
+FROM ubuntu:20.04
+
+# TODO(paulhowardarm) - Some of the contents here are common with the attester Dockerfile, and we should look at
+# making either a common base image or a Docker include.
+
+ENV DEBIAN_FRONTEND=nonintercative
+ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig
+
+RUN apt update
+RUN apt install -y autoconf-archive libcmocka0 libcmocka-dev procps
+RUN apt install -y iproute2 build-essential git pkg-config gcc libtool automake libssl-dev uthash-dev doxygen libjson-c-dev
+RUN apt install -y --fix-missing wget python3 cmake clang
+RUN apt install -y libini-config-dev libcurl4-openssl-dev curl libgcc1
+RUN apt install -y python3-distutils libclang-6.0-dev protobuf-compiler python3-pip
+RUN pip3 install Jinja2
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
+WORKDIR /tmp
+
+# Install Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:/opt/rust/bin:${PATH}"
+
+# Install regular MbedTLS (used for building purposes)
+RUN git clone https://github.com/ARMmbed/mbedtls.git
+RUN cd mbedtls \
+	&& git checkout v3.0.0 \
+	&& ./scripts/config.py crypto \
+	&& make \
+	&& make install
+ENV MBEDTLS_PATH=/tmp/mbedtls
+ENV MBEDTLS_INCLUDE_DIR=$MBEDTLS_PATH/include
+
+# Build and install QCBOR
+RUN git clone https://github.com/laurencelundblade/QCBOR
+RUN cd QCBOR \
+	&& make \
+	&& make install
+
+# Build and install t_cose
+RUN git clone https://github.com/laurencelundblade/t_cose
+RUN cd t_cose \
+	&& env CRYPTO_LIB=/usr/local/lib/libmbedcrypto.a CRYPTO_INC="-I $MBEDTLS_INCLUDE_DIR" QCBOR_LIB="-lqcbor -lm" make -f Makefile.psa -e \
+	&& make -f Makefile.psa install
+
+# Build and install ctoken
+RUN git clone https://github.com/laurencelundblade/ctoken.git
+RUN cd ctoken \
+	&& env CRYPTO_LIB=/usr/local/lib/libmbedcrypto.a CRYPTO_INC="-I $MBEDTLS_INCLUDE_DIR" QCBOR_LIB="-lqcbor -lm" make -f Makefile.psa -e \
+	&& mkdir -p /usr/local/include/ctoken \
+	&& install -m 644  inc/ctoken/ctoken* /usr/local/include/ctoken \
+	&& install -m 644 libctoken.a /usr/local/lib
+
+# Build and install the C client to Veraison, which is a wrapper of the Rust client
+RUN git clone https://github.com/veraison/rust-apiclient.git
+RUN cd rust-apiclient \
+    && cargo build \
+    && mkdir -p /usr/local/include/veraison \
+    && install -m 644 c-wrapper/veraison_client_wrapper.h /usr/local/include/veraison \
+    && install -m 644 ./target/debug/libveraison_apiclient_ffi.a /usr/local/lib
+
+# Build and install libjwt/jansson, required by c-ear library
+RUN git clone --depth 1 --branch v1.15.2  https://github.com/benmcollins/libjwt.git
+RUN cd libjwt \
+    && mkdir _build \
+    && cd _build \
+    && cmake -DUSE_INSTALLED_JANSSON=OFF -DJANSSON_BUILD_DOCS=OFF .. \
+    && cmake --build . --target install
+
+# Build and install the C EAR library (Entity Attestation Results)
+RUN git clone https://github.com/veraison/c-ear.git
+RUN cd c-ear \
+    && mkdir _build \
+    && cd _build \
+    && cmake .. \
+    && cmake --build . --target install
+
+# Build relying party MbedTLS
+RUN cd mbedtls \
+	&& make clean \
+	&& git reset --hard HEAD \
+	&& git remote add paulh https://github.com/paulhowardarm/mbedtls.git \
+	&& git fetch paulh ph-tls-attestation  \
+	&& git checkout ph-tls-attestation \
+	&& make CFLAGS="-DCTOKEN_LABEL_CNF=8 -DCTOKEN_TEMP_LABEL_KAK_PUB=2500" LDFLAGS="-lctoken -lt_cose -lqcbor -lveraison_apiclient_ffi -lear -ljwt -ljansson -lm -lssl -lcrypto -lgcc_s -lutil -lrt -lpthread -ldl -lc" \
+	&& install -m 644 programs/ssl/ssl_server2 /usr/local/bin
+
+WORKDIR /root/

--- a/demo/verifier/mock_verifier.Dockerfile
+++ b/demo/verifier/mock_verifier.Dockerfile
@@ -1,0 +1,4 @@
+FROM wiremock/wiremock
+
+# Copy the stubs (canned API responses) into the image
+COPY wiremock /home/wiremock

--- a/demo/verifier/wiremock/mappings/challenge_response.json
+++ b/demo/verifier/wiremock/mappings/challenge_response.json
@@ -1,0 +1,28 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/challenge-response/v1/session/12345678"
+    },
+    "response": {
+        "status": 200,
+        "headers": {
+            "Content-Type": "application/vnd.veraison.challenge-response-session+json"
+        },
+        "jsonBody": {
+            "nonce": "MDEyMzQ1Njc=",
+            "expiry": "2030-10-12T07:20:50.52Z",
+            "accept": [
+                "application/psa-attestation-token",
+                "application/vnd.1",
+                "application/vnd.2",
+                "application/vnd.3"
+            ],
+            "status": "complete",
+            "evidence": {
+                "type": "application/psa-attestation-token",
+                "value": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="
+            },
+            "result": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJlYXIucmF3LWV2aWRlbmNlIjoiTnpRM01qWTVOek0yTlRZek56UUsiLCJlYXIudmVyaWZpZXItaWQiOnsiYnVpbGQiOiJ2dHMgMC4wLjEiLCJkZXZlbG9wZXIiOiJodHRwczovL3ZlcmFpc29uLXByb2plY3Qub3JnIn0sImVhdF9wcm9maWxlIjoidGFnOmdpdGh1Yi5jb20sMjAyMzp2ZXJhaXNvbi9lYXIiLCJpYXQiOjEuNjY2NTI5MTg0ZSswOSwianRpIjoiMzhkZWI4NmI4NzRkZmRmNDU3YWY1OWUwMWZjZjM3ZTdhYjMwMGNlMTUxZjNkMTlhOTE5OWMyMzI4MjQxMTlmZiIsIm5iZiI6MTY3ODcxOTIzMiwic3VibW9kcyI6eyJQQVJTRUNfVFBNIjp7ImVhci5hcHByYWlzYWwtcG9saWN5LWlkIjoicG9saWN5Oi8vcGFyc2VjLzYwYTAwNjhkIiwiZWFyLnN0YXR1cyI6ImFmZmlybWluZyIsImVhci50cnVzdHdvcnRoaW5lc3MtdmVjdG9yIjp7ImV4ZWN1dGFibGVzIjoyLCJoYXJkd2FyZSI6MiwiaW5zdGFuY2UtaWRlbnRpdHkiOjJ9LCJlYXIudmVyYWlzb24ua2V5LWF0dGVzdGF0aW9uIjp7ImFrcHViIjoiTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFZDNKbGI0RkxPWko1MWVIeGVCLXNid21hUEZ5aHNPTlRVWU5MQ0xaZUMxY2xrTTJ2ajNhVFlienpTc19CSGw0SFRvUW12ZDRFdm01bE9VVkVsaGZlUlEifX19fQ.55BUrxOUO-fu5lvDXiXyhFTsf3qNES66YZMxvx30ynS7Kjzp_h3ARngIew1QZPsdHDC-HowxSO617Jr_S5au0A"
+        }
+    }
+}

--- a/demo/verifier/wiremock/mappings/new_session.json
+++ b/demo/verifier/wiremock/mappings/new_session.json
@@ -1,0 +1,24 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/challenge-response/v1/newSession"
+    },
+    "response": {
+        "status": 201,
+        "headers": {
+            "Content-Type": "application/vnd.veraison.challenge-response-session+json",
+            "Location": "http://{{request.host}}:{{request.port}}/challenge-response/v1/session/12345678"
+        },
+        "jsonBody": {
+            "nonce": "MDEyMzQ1Njc=",
+            "expiry": "2030-10-12T07:20:50.52Z",
+            "accept": [
+                "application/psa-attestation-token",
+                "application/vnd.1",
+                "application/vnd.2",
+                "application/vnd.3"
+            ],
+            "status": "waiting"
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a Docker build for the components of the relying party, similar to the one that already exists for the attester. It also includes a mocked verifier, but this is just a temporary convenience and not intended to be a final part of the PoC.

Signed-off-by: Paul Howard <paul.howard@arm.com>