### PR TITLE
Wiremock response for the discovery API

### DIFF
--- a/demo/verifier/wiremock/mappings/discovery.json
+++ b/demo/verifier/wiremock/mappings/discovery.json
@@ -1,0 +1,28 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPath": "/.well-known/veraison/verification"
+    },
+    "response": {
+        "status": 200,
+        "headers": {
+            "Content-Type": "application/vnd.veraison.discovery+json"
+        },
+        "jsonBody": {
+            "ear-verification-key": {
+                "crv": "P-256",
+                "kty": "EC",
+                "x": "usWxHK2PmfnHKwXPS54m0kTcGJ90UiglWiGahtagnv8",
+                "y": "IBOL-C3BttVivg-lSreASjpkttcsz-1rb7btKLv8EX4"
+            },
+            "media-types": [
+                "application/eat-cwt; profile=http://arm.com/psa/2.0.0",
+                "application/pem-certificate-chain",
+                "application/vnd.enacttrust.tpm-evidence",
+                "application/eat-collection; profile=http://arm.com/CCA-SSD/1.0.0",
+                "application/psa-attestation-token"
+            ],
+            "version": "commit-cb11fa0"
+        }
+    }
+}

--- a/demo/verifier/wiremock/mappings/discovery.json
+++ b/demo/verifier/wiremock/mappings/discovery.json
@@ -24,7 +24,7 @@
                 "application/psa-attestation-token"
             ],
             "version": "commit-cb11fa0",
-            "state": "READY",
+            "service-state": "READY",
             "api-endpoints": {
                 "newChallengeResponseSession": "/challenge-response/v1/newSession"
             }

--- a/demo/verifier/wiremock/mappings/discovery.json
+++ b/demo/verifier/wiremock/mappings/discovery.json
@@ -13,7 +13,8 @@
                 "crv": "P-256",
                 "kty": "EC",
                 "x": "usWxHK2PmfnHKwXPS54m0kTcGJ90UiglWiGahtagnv8",
-                "y": "IBOL-C3BttVivg-lSreASjpkttcsz-1rb7btKLv8EX4"
+                "y": "IBOL-C3BttVivg-lSreASjpkttcsz-1rb7btKLv8EX4",
+                "alg": "ES256"
             },
             "media-types": [
                 "application/eat-cwt; profile=http://arm.com/psa/2.0.0",

--- a/demo/verifier/wiremock/mappings/discovery.json
+++ b/demo/verifier/wiremock/mappings/discovery.json
@@ -23,7 +23,11 @@
                 "application/eat-collection; profile=http://arm.com/CCA-SSD/1.0.0",
                 "application/psa-attestation-token"
             ],
-            "version": "commit-cb11fa0"
+            "version": "commit-cb11fa0",
+            "state": "READY",
+            "api-endpoints": {
+                "newChallengeResponseSession": "/challenge-response/v1/newSession"
+            }
         }
     }
 }


### PR DESCRIPTION
Create a Wiremock response that is representative of what Veraison will return for the well-known discovery API for verification.

(Provisioning discovery is not covered here, because only the relying party is using this mock)

Signed-off-by: Paul Howard <paul.howard@arm.com>