### PR TITLE
Update attester with token claim fix

### DIFF
--- a/demo/attester/attester.Dockerfile
+++ b/demo/attester/attester.Dockerfile
@@ -58,7 +58,7 @@ ENV PATH="/root/.cargo/bin:/opt/rust/bin:${PATH}"
 # Install Parsec service
 RUN git clone -b attested-tls https://github.com/ionut-arm/parsec.git \
 	&& cd parsec \
-	&& git checkout dc561a5e4dee998ded29c7bd3310429341ddf237 \
+	&& git checkout 1ac2060531b391ff1f335369dc4d1e4f17aee1aa \
 	&& cargo build --release --features=tpm-provider \
 	&& cp ./target/release/parsec /usr/bin/
 RUN mkdir /etc/parsec/

--- a/doc/format-definitions/parsec-platform-evidence-tpm.md
+++ b/doc/format-definitions/parsec-platform-evidence-tpm.md
@@ -65,8 +65,8 @@ The steps for verifying the attestation:
 - Verify that `kid` identifies an endorsed key.
 - Verify that the signing algorithm defined in `sig` is consistent with the key
    identified by `kid`.
-- Verify the `sig` is a valid signature over `certInfo` using the key identified
-   by `kid`.
+- Verify the `sig` is a valid signature over `attestInfo` using the key
+   identified by `kid`.
 - Verify that `attestInfo` is valid:
    - Verify that `magic` is set to TPM_GENERATED_VALUE.
    - Verify that `type` is set to TPM_ST_ATTEST_QUOTE.


### PR DESCRIPTION
This update to the attester container brings in a fix for the TPM platform token. The previously-named certInfo claim is now replaced by attestInfo.